### PR TITLE
Jackiebarnes patch 2

### DIFF
--- a/pages/accessrecord/accessrecord_design.md
+++ b/pages/accessrecord/accessrecord_design.md
@@ -26,9 +26,9 @@ What is the scope of what views we're aiming to deliver?
 
 ### Record In Transit ###
 
-There is a risk that the GP record may be incomplete if the patient's record is undergoing a transfer.
+In the scenario where the patient's GP record is not 'fully integrated' into the 'new' GP, following a GP transfer, then only data entered to the new GP's record SHALL be provided.  A warning message stating that the record is either not available (no data entered to the new GP record), or incomplete due to the transfer.
 
-- <span class="label label-success">SELECTED</span> Provider to supply a warning that the record could be incomplete.
+- <span class="label label-success">SELECTED</span> Provider to supply appropriate warning message as to no data or incomplete data due to transfer
 - Other.
 
 ## HTML Sections ##

--- a/pages/accessrecord/accessrecord_development_html_implementation_guide.md
+++ b/pages/accessrecord/accessrecord_development_html_implementation_guide.md
@@ -138,9 +138,20 @@ Consumer Systems SHALL display the date range applied to a section's data, as su
 
 ```html
 <div>
-	<p>For the period 'dd-mmm-yyyy' to 'dd-mmm-yyyy'</p>  or 'All Data Items'
+	<p>For the period 'dd-mmm-yyyy' to 'dd-mmm-yyyy'</p>  
+
 </div>
 ```
+
+#### Default Date Ranges ####
+
+Where the Consumer System has not supplied a date-range, then where applicable and while the default is for ALL items to be provided, the following message SHALL be supplied by the Provider and displayed by the Consumer System beneath the Section Header
+
+```html
+<div>
+	<p>All relevant items subject to Patient preferences and/or legal exclusions</p>
+</div>
+``` 
 
 #### Section Content Message ####
 

--- a/pages/accessrecord/accessrecord_development_html_implementation_guide.md
+++ b/pages/accessrecord/accessrecord_development_html_implementation_guide.md
@@ -129,6 +129,10 @@ If a GP principal system can't meaningfully supply content for a requested HTML 
 	<p>'[section]' data is not supported by this system.</p>
 </div>
 ```
+### Consumer-Supplied Date Ranges ###
+
+For these, the Provider SHALL supply all matching dates/times, eg the period 2011-05-23 to 2011-05-27 includes all items with times from the start of the 23rd May through to the end of the 27th of May.
+
 
 ### Section Banner ###
 

--- a/pages/accessrecord/accessrecord_development_html_implementation_guide.md
+++ b/pages/accessrecord/accessrecord_development_html_implementation_guide.md
@@ -134,6 +134,12 @@ If a GP principal system can't meaningfully supply content for a requested HTML 
 For these, the Provider SHALL supply all matching dates/times, eg the period 2011-05-23 to 2011-05-27 includes all items with times from the start of the 23rd May through to the end of the 27th of May.
 
 
+### Record In Transit ###
+
+In the scenario where the patient's GP record is not 'fully integrated' into the 'new' GP, following a GP transfer, then only data entered to the new GP's record SHALL be provided. A warning message stating that the record is either not available (no data entered to the new GP record), or incomplete due to the transfer, SHALL be provided and displayed.
+
+
+
 ### Section Banner ###
 
 #### Applied Date Ranges ####

--- a/pages/accessrecord/accessrecord_development_html_implementation_guide.md
+++ b/pages/accessrecord/accessrecord_development_html_implementation_guide.md
@@ -175,7 +175,7 @@ Section Default Time Frames SHALL be configurable, to be easily amendable if req
 | MED  | All Relevant | Medication, MedicationOrder, MedicationDispense, MedicationAdministration |
 | OBS  | All Relevant | Observation |
 | PAT  | - | Patient |
-| PRB  | All Relevant | Problem<sup>1</sup> |
+| PRB  | All Relevant | Problem|
 | REF  | All Relevant | Referral |
 | SUM  | - | Summary |
 

--- a/pages/accessrecord/accessrecord_development_html_implementation_guide.md
+++ b/pages/accessrecord/accessrecord_development_html_implementation_guide.md
@@ -176,7 +176,7 @@ Section Default Time Frames SHALL be configurable, to be easily amendable if req
 | OBS  | All Relevant | Observation |
 | PAT  | - | Patient |
 | PRB  | All Relevant | Problem<sup>1</sup> |
-| REF  | X years | Referral<sup>2</sup> |
+| REF  | All Relevant | Referral |
 | SUM  | - | Summary |
 
 <sup>1</sup> An explicit time frame is not allowed to be specified as the system SHALL return 'All Relevant' resources.

--- a/pages/accessrecord/accessrecord_view_medications.md
+++ b/pages/accessrecord/accessrecord_view_medications.md
@@ -22,7 +22,7 @@ Contains three sections:
 
 ### Section Banner Content Message ###
 
-Providers message describing at a summary level how they have populated this section, to include the following:
+Providers message describing at a summary level how they have populated this section, and also the warning message where medications prescribed elsewhere have been excluded:  "Medications prescribed elsewhere have been excluded"
 
 | Provider | Message |
 | ------------ | ------------ |-

--- a/pages/accessrecord/accessrecord_view_medications.md
+++ b/pages/accessrecord/accessrecord_view_medications.md
@@ -53,7 +53,7 @@ A list of all current acute and repeat medications issued to a patient ordered b
 
 ### Date Horizon ###
 
-All relevant records SHALL be returned with-in Consumer supplied date range.
+All relevant records SHALL be returned.
 
 ### Table Construction ###
 
@@ -177,7 +177,9 @@ All relevant records SHALL be returned (i.e. no time limit/filtering is to be ap
 
 ### Purpose ###
 
-A list of all past medications, issued to a patient ordered by date descending (i.e. most recent date/time first). The type will include Acute, or Repeat.  Where the medication was cancelled (Acute) or Discontinued (Repeat), this should be included in the Details column as Cancelled followed by Date of Cancellation or Discontinued, followed by Date when discontinued.
+A list of all past medications, issued to a patient ordered by date descending (i.e. most recent date/time first). The type will include Acute, or Repeat. 
+
+Where the medication was cancelled (Acute) or Discontinued (Repeat), this should be included in the Details column as Cancelled followed by Date of Cancellation or Discontinued, followed by Date when discontinued.
 
 ### Structured Data ###
 

--- a/pages/development/development_fhir_api_guidance.md
+++ b/pages/development/development_fhir_api_guidance.md
@@ -55,7 +55,7 @@ To help API implementers deal with the FHIR learning curve NHS Digital has worke
 2. [Domain Resource](https://www.hl7.org/fhir/DSTU2/domainresource.html)
 	1. Common API
 		1. [Patient](https://www.hl7.org/fhir/DSTU2/patient.html) profiled as gpconnect-patient-1.
-		2. [Patient](https://www.hl7.org/fhir/DSTU2/practitioner.html) profiled as gpconnect-practitioner-1.
+		2. [Practitioner](https://www.hl7.org/fhir/DSTU2/practitioner.html) profiled as gpconnect-practitioner-1.
 		3. [Organization](https://www.hl7.org/fhir/DSTU2/organization.html) profiled as gpconnect-organization-1.
 		4. [Location](https://www.hl7.org/fhir/DSTU2/location.html) profiled as gpconnect-location-1
 	2. Care Record API

--- a/pages/development/development_fhir_operation_guidance.md
+++ b/pages/development/development_fhir_operation_guidance.md
@@ -22,7 +22,7 @@ summary: "Details of which operations a FHIR server should expose to be a fully 
 
 All `InteractionIDs` are expected to follow the following format `urn:nhs:names:services:[program]:[standard]:[mechanism]:[operation]:[subject]`.
 
-- Program = `gpconnet`
+- Program = `gpconnect`
 - Standard = `fhir`
 - Mechanism = [ `rest`, `operation` ]
 	- `rest` for RESTful API Interactions.

--- a/pages/integration/integration_cross_organisation_audit_and_provenance.md
+++ b/pages/integration/integration_cross_organisation_audit_and_provenance.md
@@ -128,6 +128,7 @@ eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJpc3MiOiJodHRwOi8vZWMyLTU0LTE5NC0xMDktMTg0
 
 {% include important.html content="Whilst the use of a JWT and the claims naming is inspired by the [SMART on FHIR](https://github.com/smart-on-fhir/smart-on-fhir.github.io/wiki/cross-organizational-auth) the GP Connect programme hasn't commit to using the SMART on FHIR specification." %}
 
+Where the Practitioner has both a local system role as well as a Spine RBAC role, then the Spine RBAC role SHALL be supplied
 {% include todo.html content="Spine RBAC role support to be added in [Stage 2.](designprinciples_maturity_model.html)" %}
 
 ### Example Code ###

--- a/pages/integration/integration_cross_organisation_audit_and_provenance.md
+++ b/pages/integration/integration_cross_organisation_audit_and_provenance.md
@@ -33,7 +33,7 @@ Consumer system SHALL generate a new JWT for each API request.
 
 <sup>2</sup> Patient scope for patient centric APIs (i.e. Get Care Record and Patient's Appointments, Patient Task) or scope for organisation centric APIs (i.e. Get Organization Schedule)
 
-<sup>3</sup> To contain the practitioners local system identifier(s) (i.e. login details / username).
+<sup>3</sup> To contain the practitioners local system identifier(s) (i.e. login details / username). Where the user has both a local system 'role' as well as a nationally-recognised role, then the latter SHALL be provided
 
 Consumer systems SHALL generate the JSON Web Token (JWT) consisting of three parts seperated by dots (.), which are:
 

--- a/pages/integration/integration_spine_security_proxy_implementation_guide.md
+++ b/pages/integration/integration_spine_security_proxy_implementation_guide.md
@@ -76,7 +76,7 @@ Servicing a consumer system’s request for a FHIR endpoint located on a provide
 | 3.   | Lookup what capabilities exist at that organisation to support access to the record. | | SDS or FHIR ELS | 3a) The consumer system SHALL resolve the endpoint of the provider system using an organisational identifier (i.e. ODS code) against SDS. <br/><br/>OR (when available^) 3b) The proxy system SHALL resolve the endpoint of the provider system using a consumer system supplied identifier (i.e. patient NHS number). <br/><br/>OR (when available^) The consumer system SHALL resolve the endpoint of the provider system using a FHIR ELS RESTful query. |
 | 4.   | Consumer requests the record. | SSP | The consumer system SHALL build a request URL using the proxy endpoint and either the endpoint of the provider <br/><br/>OR (when available^) the NHS number of the patient<sup>2</sup>. <br/><br/>The consumer system SHALL issue the request to the proxy system over a secure channel. |
 | 5.   | Lookup the patient’s sharing preferences. | PPR | Out of scope for GP Connect FoT. |
-| 6.   | Lookup organisational data sharing agreements. | DSAR | Out of scope for GP Connect FoT. |
+| 6.   | Lookup organisational data sharing. | DSAR |  |
 | 7.   | Proxy retrieves the record (throttling as required^) and returns to the consumer system. | SSP | The proxy system SHALL forward on the consumer systems request and return the provider systems response over a secure channel. |
 
 <sup>^</sup> will be made available after the initial GP Connect FoT go-live.


### PR DESCRIPTION
Reflecting changes including

In-transit record wording
#45, #46 Date-range consistency for Meds
#41 Split date range examples
Start date to end date inclusive date/times - more specific wording
Default 'All' items Section Banner msg wording
Wording for Consumer to specifically apply Spine RBAC rather than local where there's both
Referrals section on Impl Guide indicated as Stage 2 - removed this

