### PR TITLE
Release access record 1.0.0-rc.3

### DIFF
--- a/_data/sidebars/accessrecord_sidebar.yml
+++ b/_data/sidebars/accessrecord_sidebar.yml
@@ -1,7 +1,7 @@
 entries:
 - title: Access Record
   product: Access Record<br/>
-  version: 1.0.0-rc.2
+  version: 1.0.0-rc.3
   folders:
 
   - title:

--- a/pages/accessrecord/accessrecord_development_html_implementation_guide.md
+++ b/pages/accessrecord/accessrecord_development_html_implementation_guide.md
@@ -129,6 +129,7 @@ If a GP principal system can't meaningfully supply content for a requested HTML 
 	<p>'[section]' data is not supported by this system.</p>
 </div>
 ```
+
 ### Consumer-Supplied Date Ranges ###
 
 For these, the Provider SHALL supply all matching dates/times, eg the period 2011-05-23 to 2011-05-27 includes all items with times from the start of the 23rd May through to the end of the 27th of May.

--- a/pages/accessrecord/accessrecord_release_notes.md
+++ b/pages/accessrecord/accessrecord_release_notes.md
@@ -6,28 +6,50 @@ sidebar: accessrecord_sidebar
 permalink: accessrecord_release_notes.html
 summary: "Release notes for the various versions of the Access Record capability."
 ---
-- 1.0.0-rc.2 (Released: 6th December) 
 
-   - The elaboration of page(s) content to reflect the validation of data-sharing agreements by the Spine Security Proxy only, and the requirement that Provider Data-Sharing configuration should not be applied or changed for GP Connect interactions 
-  - The application of a configurable Legal Exclusion set - currently the RGCP set on TRUD -  which is being reviewed with amendments/changes expected Feb 2017
-   - The indication of withheld information, either arising from Patient preferences, or the application of the exclusion set to be at line item level as well as in Section Banner , as this provides more valuable information as to when and volume of exclusions
-  - Configurable Section Headings
-  - Configurable Section Default Date Ranges
-  - Section Content Messages for provider-specific description of how sections have been populated, or where content deviates from specification - eg Clinical/Administrative Items content; Problem 'Significance' values;  Patient withheld data indication;   see Section Pages
-  - Default section date range where relevant to be 'All' items, where Consumer date-range not supplied
-  - Section Heading Changes to: Current Repeat Medications, Problems and Issues, Allergies and Adverse Reactions
-  - Current Repeat Medications section - Last Issued Column to be first column in table
-  - Medication sections 'Drug' column heading to be 'Medication Item'
-  - Past Medications section - to include references to Discontinued Repeats, Cancelled Acutes, either as 'Type', or within Details column
-  - Investigations Section to be out of scope for Stage 1, pending further analysis
-  - Observations Section to include Investigation items
-  - Observations to be excluded from Clinical Items Section
-  - Medications Sections to be reviewed as part of Stage 2
-  - GP Name in Patient Banner (Details) to be the 'Usual' GP
+#### 1.0.0-rc.3 (Released: 6th February)
+
+- Updated [Access Record HTML Implementation Guide](accessrecord_development_html_implementation_guide.html)  
+  - Added wording around 'In-transit' record to this page.
+  - Added additional wording for Consumer Date-Ranges to include all times from the start date to the end of the end date.
+  - Default Time-Frames -  Problems, removed footnote indicating that this section should not have time-frames applied;  time-frames are NOT applied for Active Probs, but are applied for 'Inactive Probs' sub-section
+- Updated [Integration Cross Organisation Audit and Provenance](integration_cross_organisation_audit_and_provenance.html)
+  - Added wording such that in the scenario where the user has a local role as well as a national role, then the national RBAC role shall be provided
+  - Added a sentence to require the Spine RBAC role to be supplied where available and in preference to a local system role
+- Updated [Access Record Design Decisions](accessrecord_design.html)
+  - Improved wording to make more specific around Patient Record 'In-transit'
+  - Corrected the reference to SCR timeframes 
+  - Made more explicit the 'In-transit' record guidance
+- Updated [Medications](accessrecord_view_medications.html)
+  - Past Medications subsection to have consumer supplied date range applied
+- Updated [Spine Security Proxy Implementation Guide](integration_spine_security_proxy_implementation_guide.html)
+  - Step 6 in the Operating Principle table - Data-Sharing validation check - interim DSAR solution within SSP, strategic solution out of scope for FoT.
+
+
+#### 1.0.0-rc.2 (Released: 6th December) 
+
+- The elaboration of page(s) content to reflect the validation of data-sharing agreements by the Spine Security Proxy only, and the requirement that Provider Data-Sharing configuration should not be applied or changed for GP Connect interactions 
+- The application of a configurable Legal Exclusion set - currently the RGCP set on TRUD -  which is being reviewed with amendments/changes expected Feb 2017
+- The indication of withheld information, either arising from Patient preferences, or the application of the exclusion set to be at line item level as well as in Section Banner , as this provides more valuable information as to when and volume of exclusions
+- Configurable Section Headings
+- Configurable Section Default Date Ranges
+- Section Content Messages for provider-specific description of how sections have been populated, or where content deviates from specification - eg Clinical/Administrative Items content; Problem 'Significance' values;  Patient withheld data indication;   see Section Pages
+- Default section date range where relevant to be 'All' items, where Consumer date-range not supplied
+- Section Heading Changes to: Current Repeat Medications, Problems and Issues, Allergies and Adverse Reactions
+- Current Repeat Medications section - Last Issued Column to be first column in table
+- Medication sections 'Drug' column heading to be 'Medication Item'
+- Past Medications section - to include references to Discontinued Repeats, Cancelled Acutes, either as 'Type', or within Details column
+- Investigations Section to be out of scope for Stage 1, pending further analysis
+- Observations Section to include Investigation items
+- Observations to be excluded from Clinical Items Section
+- Medications Sections to be reviewed as part of Stage 2
+- GP Name in Patient Banner (Details) to be the 'Usual' GP
   
-- 1.0.0-rc.1 (Released: September 2016)
-  - Beta version promoted to release candidate
-- 1.0.0-beta.1 (Release: August 2016)
-  - Initial release of the Access Record capability pack on GitHub in early August 2016.
-- 1.0.0-alpha.1 (Released: May 2016)
-  - Initial release for feedback/comments as part of the late May 2016 release. 
+#### 1.0.0-rc.1 (Released: September 2016)
+- Beta version promoted to release candidate
+
+#### 1.0.0-beta.1 (Release: August 2016)
+- Initial release of the Access Record capability pack on GitHub in early August 2016.
+
+#### 1.0.0-alpha.1 (Released: May 2016)
+- Initial release for feedback/comments as part of the late May 2016 release. 

--- a/pages/accessrecord/accessrecord_view_medications.md
+++ b/pages/accessrecord/accessrecord_view_medications.md
@@ -187,7 +187,7 @@ Where the medication was cancelled (Acute) or Discontinued (Repeat), this should
 
 ### Date Horizon ###
 
-All relevant records SHALL be returned (i.e. no time limit/filtering is to be applied).
+All relevant records SHALL be returned according to consumer-supplied date range.
 
 ### Section Banner Content Message ###
 

--- a/pages/integration/integration_spine_security_proxy_implementation_guide.md
+++ b/pages/integration/integration_spine_security_proxy_implementation_guide.md
@@ -76,7 +76,7 @@ Servicing a consumer system’s request for a FHIR endpoint located on a provide
 | 3.   | Lookup what capabilities exist at that organisation to support access to the record. | | SDS or FHIR ELS | 3a) The consumer system SHALL resolve the endpoint of the provider system using an organisational identifier (i.e. ODS code) against SDS. <br/><br/>OR (when available^) 3b) The proxy system SHALL resolve the endpoint of the provider system using a consumer system supplied identifier (i.e. patient NHS number). <br/><br/>OR (when available^) The consumer system SHALL resolve the endpoint of the provider system using a FHIR ELS RESTful query. |
 | 4.   | Consumer requests the record. | SSP | The consumer system SHALL build a request URL using the proxy endpoint and either the endpoint of the provider <br/><br/>OR (when available^) the NHS number of the patient<sup>2</sup>. <br/><br/>The consumer system SHALL issue the request to the proxy system over a secure channel. |
 | 5.   | Lookup the patient’s sharing preferences. | PPR | Out of scope for GP Connect FoT. |
-| 6.   | Lookup organisational data sharing. | DSAR |  |
+| 6.   | Lookup organisational data sharing. | DSAR | Interim solution as part of SSP.  Strategic solution out of scope for GP Connect FoT. |
 | 7.   | Proxy retrieves the record (throttling as required^) and returns to the consumer system. | SSP | The proxy system SHALL forward on the consumer systems request and return the provider systems response over a secure channel. |
 
 <sup>^</sup> will be made available after the initial GP Connect FoT go-live.

--- a/pages/integration/integration_system_topologies.md
+++ b/pages/integration/integration_system_topologies.md
@@ -33,7 +33,7 @@ Note the ASID for each system which consumes data from the GP record.  Also plea
 
 ## Regional Shared Care Record ##
 
-![Shared Care Record](images/integration/topology4-hostedRegionalCareRecord.png)
+![Shared Care Record](images/integration/topology4-hostedregionalcarerecord.png)
 
 A regional shared care initiative hosted by one of the participating organisations might have a topology similar to this.  This  illustrates a consuming portal deployment. The hosting organisation holds the ASID for the consumer application and (subject to the usual governance controls) the data can be shared via the portal to other organisations.
 


### PR DESCRIPTION
1.0.0-rc.3 (Released: 6th February)
Updated Access Record HTML Implementation Guide
Added wording around 'In-transit' record to this page.
Added additional wording for Consumer Date-Ranges to include all times from the start date to the end of the end date.
Default Time-Frames - Problems, removed footnote indicating that this section should not have time-frames applied; time-frames are NOT applied for Active Probs, but are applied for 'Inactive Probs' sub-section
Updated Integration Cross Organisation Audit and Provenance
Added wording such that in the scenario where the user has a local role as well as a national role, then the national RBAC role shall be provided
Added a sentence to require the Spine RBAC role to be supplied where available and in preference to a local system role
Updated Access Record Design Decisions
Improved wording to make more specific around Patient Record 'In-transit'
Corrected the reference to SCR timeframes
Made more explicit the 'In-transit' record guidance
Updated Medications
Past Medications subsection to have consumer supplied date range applied
Updated Spine Security Proxy Implementation Guide
Step 6 in the Operating Principle table - Data-Sharing validation check - interim DSAR solution within SSP, strategic solution out of scope for FoT.