### PR TITLE
ARS-369: Added link to FHIR search guidance

### DIFF
--- a/pages/access_documents/access_documents_development_search_patient_documents.md
+++ b/pages/access_documents/access_documents_development_search_patient_documents.md
@@ -11,6 +11,8 @@ summary: "Search for a patient's documents"
 
 Search for a patient's documents from a GP practice.
 
+We assume an understanding of FHIR REST and search features. For further information with regards to the features described in this page see [http://hl7.org/fhir/STU3/search.html](http://hl7.org/fhir/STU3/search.html).
+
 ## Security ##
 
 - GP Connect utilises TLS Mutual Authentication for system level authorization


### PR DESCRIPTION
Changes from Jira ticket https://nhsd-jira.digital.nhs.uk/browse/ARS-369 adding a single line of guidance to search page indicating that the user should be familiar with FHIR search principles, and where to find said documentation for more info.